### PR TITLE
Add Timmy's First CloudFormation lab

### DIFF
--- a/sns.tf
+++ b/sns.tf
@@ -1,0 +1,4 @@
+# LAB: Timmy's First CloudFormation
+resource "aws_sns_topic" "default" {
+  name = "SecurityAlerts"
+}


### PR DESCRIPTION
Although we could technically use Terraform to manage CloudFormation Stacks, it's much easier to convert the CloudFormation template to Terraform for easier management and auditing.