### PR TITLE
Fix CloudWatch billing alarm

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,15 +1,16 @@
 # LAB: Follow the Money!
 resource "aws_cloudwatch_metric_alarm" "billing" {
-  alarm_name          = "billing-total-estimated"
-  alarm_description   = "Monitor total estimated billing charges"
+  alarm_name          = "billing-total-estimated-10usd"
+  alarm_description   = "Alarm when AWS billing exceeds $10"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
-  period              = 28800
+  period              = 21600
   statistic           = "Maximum"
-  threshold           = 25
+  threshold           = 10
   namespace           = "AWS/Billing"
   metric_name         = "EstimatedCharges"
   alarm_actions       = [aws_sns_topic.default.arn]
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     currency = "USD"


### PR DESCRIPTION
Originally, this CloudWatch billing alarm from the "Follow the Money!" lab was misconfigured. Adjusting the period to 6 hours seems to resolve this issue.